### PR TITLE
remove unnecessary code

### DIFF
--- a/nimlapack.nim
+++ b/nimlapack.nim
@@ -1,4 +1,3 @@
- {.deadCodeElim: on.}
 when defined(windows):
   const
     libSuffix = ".dll"


### PR DESCRIPTION
Hello, @andreaferretti 

`deadCodeElim` is always enabled and first line indentation will become an error soon => https://github.com/nim-lang/Nim/pull/19666